### PR TITLE
 Avoid race condition to create more than one pool

### DIFF
--- a/src/main/java/org/bbottema/clusteredobjectpool/core/ResourceClusters.java
+++ b/src/main/java/org/bbottema/clusteredobjectpool/core/ResourceClusters.java
@@ -70,7 +70,7 @@ public class ResourceClusters<ClusterKey, PoolKey, T> {
 	 * @throws IllegalArgumentException if the pool already exists in the specified cluster.
 	 */
 	@SuppressWarnings("WeakerAccess")
-	public void registerResourcePool(@NotNull final ResourceKey<ClusterKey, PoolKey> key,
+	public synchronized void registerResourcePool(@NotNull final ResourceKey<ClusterKey, PoolKey> key,
 									 @NotNull final ExpirationPolicy<T> expirationPolicy,
 									 final int corePoolSize,
 									 final int maxPoolSize) throws IllegalArgumentException {


### PR DESCRIPTION
Hi @bbottema , 
please review this change 
why - 
Possible race condition, which can lead to more than one GenericObjectPool, however the created first will not be utilised. 
thanks, 
