### PR TITLE
fix(pool): inherit waiter recovery from generic pool 2.4.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Maven Dependency Setup
 <dependency>
 	<groupId>com.github.bbottema</groupId>
 	<artifactId>clustered-object-pool</artifactId>
-	<version>4.0.3</version>
+	<version>4.0.4</version>
 </dependency>
 ```
 
@@ -25,9 +25,9 @@ For JPMS applications, the published JAR declares the stable automatic module na
 
 ## Release Notes
 
-4.0.3 (11 August 2026)
+4.0.4 (7 September 2026)
 
-- [#8](https://github.com/bbottema/clustered-object-pool/issues/8): Declare the stable JPMS automatic module name `org.bbottema.clusteredobjectpool` and consume the fixed generic pool module.
+- [#22](https://github.com/bbottema/clustered-object-pool/issues/22): Update `generic-object-pool` to 2.4.3 so waiting keyed and load-balanced claims recover after invalidation or core-pool replenishment. The update also protects concurrent invalidation and shutdown cleanup; Java 8 and the public API are unchanged.
 
 4.0.1
 

--- a/RELEASE.txt
+++ b/RELEASE.txt
@@ -4,6 +4,17 @@ https://github.com/bbottema/clustered-object-pool
 RELEASE NOTES clustered-object-pool
 
 
+v4.0.4 (7 September 2026)
+
+- #22: Update generic-object-pool to 2.4.3 so waiting keyed and load-balanced claims recover after invalidation or core-pool replenishment; also inherit atomic invalidation and shutdown cleanup fixes (bbottema/generic-object-pool#20).
+- Public API, Java 8 baseline and JPMS automatic module names remain unchanged.
+
+
+v4.0.3 (11 August 2026)
+
+- #8: Declare the stable JPMS automatic module name org.bbottema.clusteredobjectpool and update generic-object-pool to 2.4.2.
+
+
 v4.0.2 (10 August 2026)
 
 - Update generic-object-pool to 2.4.1 so shutdown waits for allocator deallocation to finish

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
 
 	<properties>
 		<automaticModuleName>org.bbottema.clusteredobjectpool</automaticModuleName>
-		<generic-object-pool.version>2.4.2</generic-object-pool.version>
+		<generic-object-pool.version>2.4.3</generic-object-pool.version>
 		<license.owner.name>Benny Bottema</license.owner.name>
 		<license.owner.email>benny@bennybottema.com</license.owner.email>
 	</properties>

--- a/src/test/java/org/bbottema/clusteredobjectpool/ClaimRecoveryTest.java
+++ b/src/test/java/org/bbottema/clusteredobjectpool/ClaimRecoveryTest.java
@@ -1,0 +1,96 @@
+package org.bbottema.clusteredobjectpool;
+
+import org.bbottema.clusteredobjectpool.core.ClusterConfig;
+import org.bbottema.clusteredobjectpool.core.ResourceClusters;
+import org.bbottema.clusteredobjectpool.core.api.ResourceKey.ResourceClusterAndPoolKey;
+import org.bbottema.genericobjectpool.Allocator;
+import org.bbottema.genericobjectpool.PoolableObject;
+import org.bbottema.genericobjectpool.util.Timeout;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.fail;
+
+class ClaimRecoveryTest {
+
+	@ParameterizedTest
+	@CsvSource({"0,false", "0,true", "1,false", "1,true"})
+	void invalidationWakesAnExistingKeyedOrClusteredClaim(final int coreSize, final boolean selectFromCluster) throws Exception {
+		final AtomicInteger allocated = new AtomicInteger();
+		final ResourceClusters<String, String, Integer> clusters = new ResourceClusters<>(
+				ClusterConfig.<String, String, Integer>builder()
+						.allocatorFactory(key -> new Allocator<Integer>() {
+							@NotNull
+							@Override
+							public Integer allocate() {
+								return allocated.incrementAndGet();
+							}
+						})
+						.defaultExpirationPolicy(ignored -> false)
+						.defaultCorePoolSize(coreSize)
+						.defaultMaxPoolSize(1)
+						.claimTimeout(new Timeout(500, MILLISECONDS))
+						.build());
+		final ResourceClusterAndPoolKey<String, String> key = new ResourceClusterAndPoolKey<>("cluster", "pool");
+		clusters.registerResourcePool(key);
+		final Callable<PoolableObject<Integer>> claim = selectFromCluster
+				? () -> clusters.claimResourceFromCluster("cluster") : () -> clusters.claimResourceFromPool(key);
+		final ExecutorService executor = Executors.newSingleThreadExecutor();
+		final AtomicReference<Thread> waitingThread = new AtomicReference<>();
+		final AtomicReference<PoolableObject<Integer>> replacement = new AtomicReference<>();
+		final PoolableObject<Integer> original = claim.call();
+		try {
+			assertThat(original).isNotNull();
+			final Future<PoolableObject<Integer>> waiting = executor.submit(() -> {
+				waitingThread.set(Thread.currentThread());
+				final PoolableObject<Integer> result = claim.call();
+				replacement.set(result);
+				return result;
+			});
+			awaitBlockedClaim(waitingThread);
+			original.invalidate();
+			final PoolableObject<Integer> recovered = waiting.get(2, SECONDS);
+			assertThat(recovered).isNotNull().isNotSameAs(original);
+			assertThat(recovered.getAllocatedObject()).isNotEqualTo(original.getAllocatedObject());
+			assertThat(clusters.countLiveResources()).isOne();
+		} finally {
+			executor.shutdownNow();
+			assertThat(executor.awaitTermination(3, SECONDS)).isTrue();
+			if (original != null) {
+				original.invalidate();
+			}
+			if (replacement.get() != null) {
+				replacement.get().release();
+			}
+			clusters.shutDown().get(3, SECONDS);
+		}
+	}
+
+	private static void awaitBlockedClaim(final AtomicReference<Thread> thread) throws InterruptedException {
+		final long deadline = System.nanoTime() + SECONDS.toNanos(2);
+		while (System.nanoTime() < deadline) {
+			final Thread worker = thread.get();
+			if (worker != null && worker.getState() == Thread.State.TIMED_WAITING) {
+				for (StackTraceElement frame : worker.getStackTrace()) {
+					if (frame.getClassName().equals("org.bbottema.genericobjectpool.GenericObjectPool")
+							&& frame.getMethodName().equals("waitForAvailableObjectOrTimeout")) {
+						return;
+					}
+				}
+			}
+			Thread.sleep(1);
+		}
+		fail("The caller did not reach the underlying pool's condition wait");
+	}
+}


### PR DESCRIPTION
Consume the published generic-object-pool 2.4.3 fix and retain regressions for already-waiting keyed and load-balanced claims in lazy and preallocated pools. Public API and Java 8 compatibility are unchanged. Related to #22 and bbottema/generic-object-pool#20; release as 4.0.4.